### PR TITLE
NLightning.Console: fix build

### DIFF
--- a/NLightning.Console/Program.cs
+++ b/NLightning.Console/Program.cs
@@ -18,7 +18,7 @@ namespace NLightning.Console
 {
     class Program
     {
-        static void MyMain(string[] args)
+        static void Main(string[] args)
         {
             string localPrivateKey = "<node private key>";
             ECKeyPair localLightningKey = new ECKeyPair(localPrivateKey, true);


### PR DESCRIPTION
It was giving this error:
```
Build FAILED.

CSC : error CS5001: Program does not contain a static 'Main' method suitable for an entry point [/Users/knocte/Documents/Code/NLightning/NLightning.Console/NLightning.Console.csproj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:34.42
```