### PR TITLE
NLightning: migrate from .NetCore2.1 to .NetStandard2.0

### DIFF
--- a/NLightning/NLightning.csproj
+++ b/NLightning/NLightning.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>NLightning</AssemblyName>
     <RootNamespace>NLightning</RootNamespace>
     <LangVersion>7.3</LangVersion>

--- a/NLightning/Network/GossipMessages/ChannelUpdateMessageValidator.cs
+++ b/NLightning/Network/GossipMessages/ChannelUpdateMessageValidator.cs
@@ -30,7 +30,8 @@ namespace NLightning.Network.GossipMessages
             var viewConfiguration = configuration.GetConfiguration<NetworkViewConfiguration>();
             _networkViewService = networkViewService;
             _logger = loggerFactory.CreateLogger(GetType());
-            _periodicScheduler = _eventScheduler.SchedulePeriodic(viewConfiguration.UpdateInterval * 2, ClearCache);
+            var newSpan = TimeSpan.FromMilliseconds(viewConfiguration.UpdateInterval.TotalMilliseconds * 2);
+            _periodicScheduler = _eventScheduler.SchedulePeriodic(newSpan, ClearCache);
         }
         
         public void Validate(Message message, byte[] rawData)
@@ -66,7 +67,8 @@ namespace NLightning.Network.GossipMessages
             
             if (channel == null)
             {
-                var cacheEntry = _channelIdNodeIdsMapping.GetValueOrDefault(message.ShortChannelIdHex);
+                var cacheEntry = default((ECKeyPair, ECKeyPair));
+                _channelIdNodeIdsMapping.TryGetValue(message.ShortChannelIdHex, out cacheEntry);
                 if (cacheEntry.Item1 == null || cacheEntry.Item2 == null)
                 {
                     throw new MessageValidationException(message, $"ChannelUpdateMessage: Can't validate channel update message without channel announcement. Channel ID: {message.ShortChannelIdHex}");

--- a/NLightning/Network/NetworkView.cs
+++ b/NLightning/Network/NetworkView.cs
@@ -67,7 +67,9 @@ namespace NLightning.Network
         {
             lock (_syncObject)
             {
-                return _channels.GetValueOrDefault(shortChannelId);
+                var channel = default(NetworkChannel);
+                _channels.TryGetValue(shortChannelId, out channel);
+                return channel;
             }
         }
         
@@ -128,7 +130,8 @@ namespace NLightning.Network
         {
             lock (_syncObject)
             {
-                _viewStates.TryAdd(state.PeerNetworkAddress, state);
+                if (!_viewStates.TryGetValue(state.PeerNetworkAddress, out _))
+                    _viewStates.Add(state.PeerNetworkAddress, state);
             }
         }
     }

--- a/NLightning/Network/NetworkViewSyncService.cs
+++ b/NLightning/Network/NetworkViewSyncService.cs
@@ -223,7 +223,8 @@ namespace NLightning.Network
             var pendingUpdateMessages = channelUpdateMessages.Select(m => m.Message).ToList();
             foreach (var message in channelMessages.GroupBy(cm => cm.Message.ShortChannelIdHex).Select(y => y.Last()))
             {
-                var channel = channels.GetValueOrDefault(message.Message.ShortChannelIdHex);
+                var channel = default(NetworkChannel);
+                channels.TryGetValue(message.Message.ShortChannelIdHex, out channel);
                 var channelUpdateMessage = pendingUpdateMessages.LastOrDefault(m => m.ShortChannelIdHex == message.Message.ShortChannelIdHex);
 
                 if (channel != null && channelUpdateMessage != null)
@@ -249,7 +250,8 @@ namespace NLightning.Network
 
             foreach (var updateMessage in pendingUpdateMessages)
             {
-                var channel = channels.GetValueOrDefault(updateMessage.ShortChannelIdHex);
+                var channel = default(NetworkChannel);
+                channels.TryGetValue(updateMessage.ShortChannelIdHex, out channel);
                 channel?.Update(updateMessage);
             }
 
@@ -280,7 +282,8 @@ namespace NLightning.Network
             var newNodes = new Dictionary<string, NetworkNode>();
             foreach (var message in nodeAnnouncementMessages.GroupBy(cm => cm.Message.NodeIdHex).Select(y => y.Last()))
             {
-                var existingNode = nodes.GetValueOrDefault(message.Message.NodeIdHex);
+                var existingNode = default(NetworkNode);
+                nodes.TryGetValue(message.Message.NodeIdHex, out existingNode);
                 if (existingNode != null)
                 {
                     existingNode.Update(message.Message);
@@ -434,7 +437,8 @@ namespace NLightning.Network
         
         private PeerNetworkViewState GetOrCreatePeerState(string networkAddress)
         {
-            var state = _view.GetPeerStates().GetValueOrDefault(networkAddress);
+            var state = default(PeerNetworkViewState);
+            _view.GetPeerStates().TryGetValue(networkAddress, out state);
             if (state == null)
             {
                 state = new PeerNetworkViewState { PeerNetworkAddress = networkAddress } ;

--- a/NLightning/Peer/AutoConnect/PeerAutoConnectService.cs
+++ b/NLightning/Peer/AutoConnect/PeerAutoConnectService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Net.Sockets;
 using System.Reactive.Concurrency;
-using System.Reflection.Metadata.Ecma335;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using NLightning.Network;

--- a/NLightning/Peer/Discovery/DnsBootstrap.cs
+++ b/NLightning/Peer/Discovery/DnsBootstrap.cs
@@ -89,7 +89,7 @@ namespace NLightning.Peer.Discovery
 
         private ECKeyPair GetPublicKey(SrvRecord srv)
         {
-            string bech32 = srv.Target.Value.Split(".").First();
+            string bech32 = srv.Target.Value.Split('.').First();
 
             Bech32Encoder bech32Encoder = Encoders.Bech32("ln");
             var bech32Data5Bits = bech32Encoder.DecodeData(bech32);

--- a/NLightning/Transport/Handshake.cs
+++ b/NLightning/Transport/Handshake.cs
@@ -222,13 +222,15 @@ namespace NLightning.Transport
             if (_state.HandshakeState == HandshakeState.Initialized)
             {
                 (_, ECKeyPair ephemeralKey) = ReadActOneRequest(inputBuffer, inputBufferLength);
-                stream.Write(ApplyActTwo(ephemeralKey));
+                var toWrite = ApplyActTwo(ephemeralKey);
+                stream.Write(toWrite, 0, toWrite.Length);
             } 
             
             if (_state.HandshakeState == HandshakeState.Act1)
             {
                 (byte[] tempK2, ECKeyPair ephemeralKey) = ReadActTwoAnswer(inputBuffer, inputBufferLength);
-                stream.Write(ApplyActThree(tempK2, ephemeralKey));
+                var toWrite = ApplyActThree(tempK2, ephemeralKey);
+                stream.Write(toWrite, 0, toWrite.Length);
             } 
 
             if (_state.HandshakeState == HandshakeState.Act2)

--- a/NLightning/Transport/Messaging/MessageWriter.cs
+++ b/NLightning/Transport/Messaging/MessageWriter.cs
@@ -23,7 +23,7 @@ namespace NLightning.Transport.Messaging
         {
             lock (_sendLock)
             {
-                _networkStream.Write(data);
+                _networkStream.Write(data, 0, data.Length);
             }
         }
 

--- a/NLightning/Transport/NodeAddress.cs
+++ b/NLightning/Transport/NodeAddress.cs
@@ -44,7 +44,7 @@ namespace NLightning.Transport
 
         public static NodeAddress Parse(String address)
         {
-            var pubKeyAddressSplit = address.Split("@");
+            var pubKeyAddressSplit = address.Split('@');
             if (pubKeyAddressSplit.Length != 2)
             {
                 throw new ArgumentException("Invalid address format.", "address");
@@ -52,7 +52,7 @@ namespace NLightning.Transport
             
             String publicKey = pubKeyAddressSplit.First();
             String ipAndPort = pubKeyAddressSplit.Last();
-            var ipPortSplit = ipAndPort.Split(":");
+            var ipPortSplit = ipAndPort.Split(':');
             
             String ipAddress = ipPortSplit.First();
             int port = ipAndPort.Length == 2 ? Int32.Parse(ipPortSplit.Last()) : 9735;

--- a/NLightning/Utils/Extensions/ByteExtensions.cs
+++ b/NLightning/Utils/Extensions/ByteExtensions.cs
@@ -7,17 +7,20 @@ namespace NLightning.Utils.Extensions
     {        
         public static ushort ToUShortBigEndian(this byte[] data, int index = 0)
         {
-            return BitConverter.ToUInt16(data.SubArray(index, 2).Reverse().ToArray());
+            var subArray = data.SubArray(index, 2).Reverse().ToArray();
+            return BitConverter.ToUInt16(subArray, 0);
         }
        
         public static uint ToUIntBigEndian(this byte[] data, int index = 0)
         {
-            return BitConverter.ToUInt32(data.SubArray(index, 4).Reverse().ToArray());
+            var subArray = data.SubArray(index, 4).Reverse().ToArray();
+            return BitConverter.ToUInt32(subArray, 0);
         }
         
         public static ulong ToULongBigEndian(this byte[] data, int index = 0)
         {
-            return BitConverter.ToUInt64(data.SubArray(index, 8).Reverse().ToArray());
+            var subArray = data.SubArray(index, 8).Reverse().ToArray();
+            return BitConverter.ToUInt64(subArray, 0);
         }
         
         public static byte[] Combine(params byte[][] arrays)

--- a/NLightning/Utils/ZLibCompression.cs
+++ b/NLightning/Utils/ZLibCompression.cs
@@ -13,7 +13,7 @@ namespace NLightning.Utils
             using (MemoryStream inputStream = new MemoryStream(data))
             using (MemoryStream outputStream = new MemoryStream())
             {
-                outputStream.Write(ZlibDefaultCompressionHeader);
+                outputStream.Write(ZlibDefaultCompressionHeader, 0, ZlibDefaultCompressionHeader.Length);
                 
                 using (DeflateStream deflateStream = new DeflateStream(outputStream, CompressionMode.Compress))
                 {


### PR DESCRIPTION
This way, it can be consumed by Xamarin/Mono apps.

(The changes in the .cs files are needed, otherwise
the build would be broken just by retargetting.)